### PR TITLE
Dockerfileとdocker-composeの追加、.gitignoreの更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work.sum
 
 # env file
 .env
+
+# Mac OS X Finder directory files
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,14 @@
 FROM golang:tip-alpine3.21
+WORKDIR /app
+
+# go.mod と go.sum をコンテナ内にコピー
+COPY go.mod go.sum ./
+
+# 依存関係をダウンロード（Gin もこのタイミングでインストールされる）
+RUN go mod download
+
+# アプリのコードをコピー
+COPY . .
+
+# アプリを実行
+CMD ["go", "run", "main.go"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
-FROM golang:tip-alpine3.21
+FROM golang:latest
 WORKDIR /app
 
 # go.mod と go.sum をコンテナ内にコピー
 COPY go.mod go.sum ./
 
-# 依存関係をダウンロード（Gin もこのタイミングでインストールされる）
+# 依存関係の解決
+RUN go mod tidy
 RUN go mod download
 
 # アプリのコードをコピー
 COPY . .
 
+# アプリをビルド
+RUN go build -o main .
+
 # アプリを実行
-CMD ["go", "run", "main.go"]
+CMD ["./main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM golang:tip-alpine3.21

--- a/app/go.mod
+++ b/app/go.mod
@@ -1,0 +1,3 @@
+module github.com/AikawaShota/household/app
+
+go 1.24.0

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,30 @@
+services:
+  web:
+    build: .
+    container_name: gin_app
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./app:/app
+    depends_on:
+      - db
+    environment:
+      - DB_HOST=db
+      - DB_USER=postgres
+      - DB_PASSWORD=postgres
+      - DB_NAME=app_db
+      - DB_PORT=5432
+
+  db:
+    image: postgres:14.16-alpine3.20
+    ports:
+      - "5432:5432"
+    restart: always
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
+      POSTGRES_DB: "app_db"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+volumes:
+  postgres_data:

--- a/compose.yml
+++ b/compose.yml
@@ -16,7 +16,7 @@ services:
       - DB_PORT=5432
 
   db:
-    image: postgres:14.16-alpine3.20
+    image: postgres:latest
     ports:
       - "5432:5432"
     restart: always


### PR DESCRIPTION
Dockerfileの追加:
Goアプリケーション（Gin）のDocker環境を構築するための基本的な設定を追加しました。依存関係の解決やアプリケーションのビルド、実行のステップを含んでいます。

docker-compose.ymlの追加:
docker-compose.yml を追加し、Webアプリケーション（Gin）とPostgreSQLを連携させる構成を設定しました。web サービスにはGinアプリケーション、db サービスにはPostgreSQLを使用し、それぞれに必要な環境変数を設定しています。

.gitignoreの更新:
Mac OS Xの .DS_Store ファイルを無視するように .gitignore を更新しました。
go.modファイルの作成:

go mod init を実行し、Goモジュールとしてプロジェクトを初期化しました。これにより、依存関係の管理ができるようになります。